### PR TITLE
fix(autocomplete): Handle error when no argument is given to autocomplete helper

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -23,6 +23,7 @@ class Program extends GetterSetter {
     this.bin = this.makeGetterSetter('bin');
     this._bin = path.basename(process.argv[1]);
     this._autocomplete = new Autocomplete(this);
+    this._supportedShell = ['bash', 'zsh', 'fish'];
     this.logger(createLogger());
     this._defaultCommand = null;
   }
@@ -212,8 +213,8 @@ class Program extends GetterSetter {
     }
     const complete = new tabtabComplete({name: this.bin()});
 
-    if (typeof argv[1] !== "string") {
-      throw new WrongNumberOfArgumentError('Shell must be given', {}, this)
+    if (typeof argv[1] !== "string" || this._supportedShell.indexOf(argv[1]) === -1) {
+      throw new WrongNumberOfArgumentError(`Shell must be given (${this._supportedShell.join('/')})`, {}, this)
     }
     this.logger().info(complete.script(this.bin(), this.bin(), argv[1].toLowerCase()));
   }

--- a/lib/program.js
+++ b/lib/program.js
@@ -8,6 +8,7 @@ const path = require('path');
 const Autocomplete = require('./autocomplete');
 const createLogger = require('./logger').createLogger;
 const tabtabComplete  = require('tabtab/src/complete');
+const WrongNumberOfArgumentError = require('./error/wrong-num-of-arg');
 
 class Program extends GetterSetter {
 
@@ -210,6 +211,10 @@ class Program extends GetterSetter {
       return this._autocomplete.listen({"_" : args._});
     }
     const complete = new tabtabComplete({name: this.bin()});
+
+    if (typeof argv[1] !== "string") {
+      throw new WrongNumberOfArgumentError('Shell must be given', {}, this)
+    }
     this.logger().info(complete.script(this.bin(), this.bin(), argv[1].toLowerCase()));
   }
 

--- a/lib/program.js
+++ b/lib/program.js
@@ -214,9 +214,10 @@ class Program extends GetterSetter {
     const complete = new tabtabComplete({name: this.bin()});
 
     if (typeof argv[1] !== "string" || this._supportedShell.indexOf(argv[1]) === -1) {
-      throw new WrongNumberOfArgumentError(`Shell must be given (${this._supportedShell.join('/')})`, {}, this)
+      this.fatalError(new WrongNumberOfArgumentError(`Shell must be given (${this._supportedShell.join('/')})`, {}, this));
+    } else {
+      this.logger().info(complete.script(this.bin(), this.bin(), argv[1].toLowerCase()));
     }
-    this.logger().info(complete.script(this.bin(), this.bin(), argv[1].toLowerCase()));
   }
 
   /**

--- a/tests/arg-validation.js
+++ b/tests/arg-validation.js
@@ -154,4 +154,21 @@ describe("Argument validation", function() {
     should(this.action.callCount).eql(1);
   });
 
+  it(`should throw WrongNumberOfArgumentError when no argument is given to completion`, function() {
+    program.parse(makeArgv(['completion']));
+    should(this.fatalError.callCount).eql(1);
+    should(this.fatalError.calledWith(sinon.match.instanceOf(WrongNumberOfArgumentError))).be.ok();
+  });
+
+  it(`should throw WrongNumberOfArgumentError when wrong argument is given to completion`, function() {
+    program.parse(makeArgv(['completion', 'nosh']));
+    should(this.fatalError.callCount).eql(1);
+    should(this.fatalError.calledWith(sinon.match.instanceOf(WrongNumberOfArgumentError))).be.ok();
+  });
+
+  it(`should not throw any error when passing an handled argument to completion`, function() {
+    program.parse(makeArgv(['completion', 'zsh']));
+    should(this.fatalError.callCount).eql(0);
+  });
+
 });


### PR DESCRIPTION
This yet throws a generic error, as we try to `toLowerCase` an undefined variable