### PR TITLE
fix(options): Fix handling of --no-color option

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -436,7 +436,7 @@ class Command extends GetterSetter {
 
 Object.defineProperties(Command, {
   "NATIVE_OPTIONS": {
-    value: ['h', 'help', 'V', 'version', 'no-color', 'quiet', 'silent', 'v', 'verbose', 'autocomplete']
+    value: ['h', 'help', 'V', 'version', 'color', 'quiet', 'silent', 'v', 'verbose']
   }
 });
 


### PR DESCRIPTION
Using --no-color was throwing "Error: Unknown option --color"
Fixes #19 