### PR TITLE
fix(logger): Fix logger new line character after metadata

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,7 +13,7 @@ util.inherits(CaporalTransport, winston.Transport);
 
 CaporalTransport.prototype.log = function (level, msg, meta, callback) {
   if (meta !== null && typeof meta !== 'undefined') {
-    msg += "\n" + prettyjson.render(meta);
+    msg += "\n" + prettyjson.render(meta) + "\n";
   }
   const levelInt = winston.levels[level];
   const stdio = levelInt <= 1 ? 'stderr' : 'stdout';

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -22,7 +22,7 @@ describe('logger', () => {
     const oldWrite = process.stdout.write;
     process.stdout.write = write;
 
-    should(stripColor(logStr)).be.eql("foo\nfoo: bar");
+    should(stripColor(logStr)).be.eql("foo\nfoo: bar\n");
     should(callback.called).be.ok();
     should(oldWrite.called).be.ok();
   });
@@ -44,7 +44,7 @@ describe('logger', () => {
     const oldWrite = process.stderr.write;
     process.stderr.write = write;
 
-    should(stripColor(logStr)).be.eql("foo\nfoo: bar");
+    should(stripColor(logStr)).be.eql("foo\nfoo: bar\n");
     should(callback.called).be.ok();
     should(oldWrite.called).be.ok();
 


### PR DESCRIPTION
Fix logger new line character after metadata 
Fixes #25 