### PR TITLE
fix: Fix options parsing when only short name is defined

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -314,6 +314,8 @@ class Command extends GetterSetter {
     return this._options.reduce((acc, opt) => {
       if (typeof options[opt.getLongCleanName()] !== 'undefined') {
         acc[opt.name()] = options[opt.getLongCleanName()];
+      } else {
+        acc[opt.name()] = options[opt.getShortCleanName()];
       }
       return acc;
     }, {});

--- a/tests/option-validation.js
+++ b/tests/option-validation.js
@@ -265,6 +265,25 @@ describe('Setting up a required option (short)', () => {
   });
 });
 
+describe('Setting up a just one short option', () => {
+
+  it(`should work`, () => {
+
+    const action = sinon.spy();
+    program
+      .command('foo')
+      .option('-t <time-in-secs>')
+      .action(action);
+
+    program.parse(makeArgv(['foo', '-t', '2']));
+    should(action.called).be.ok();
+    console.dir(action.args[0]);
+    should(action.args[0][1]).eql({t:'2'});
+    program.reset();
+  });
+});
+
+
 describe('Setting up a option synopsis containing an error', () => {
 
   it(`should throw OptionSyntaxError`, () => {


### PR DESCRIPTION
Fix options parsing when only short name is defined. Fixes #29 