### PR TITLE
Exit after running the help command

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -34,6 +34,7 @@ class Program extends GetterSetter {
   help(cmdStr) {
     const cmd = this._commands.filter(c => (c.name() === cmdStr || c.getAlias() === cmdStr))[0];
     this._help.display(cmd);
+    process.exit(0);
   }
 
   /**


### PR DESCRIPTION
To fix this: https://github.com/mattallty/Caporal.js/issues/26 
I didn't change tests, just wanted to communicate clearly what works on my machine. I know that you had a PR fixing the issue, but it only fixed it for "--help" but not "help"