### PR TITLE
fix(help): use console.log for help() instead of custom logger

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -28,7 +28,7 @@ class Help {
 
     help += "\n\n   " + this._getGlobalOptions();
 
-    return this._program.logger().info(help + "\n");
+    return console.log(help + "\n");
   }
 
   _getCommands() {


### PR DESCRIPTION
Use console.log for help() instead of custom logger. Fixes #34