### PR TITLE
Remove hardcoded dependency on a process argument.

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -21,7 +21,6 @@ class Program extends GetterSetter {
     this.description = this.makeGetterSetter('description');
     this.logger = this.makeGetterSetter('logger');
     this.bin = this.makeGetterSetter('bin');
-    this._bin = path.basename(process.argv[1]);
     this._autocomplete = new Autocomplete(this);
     this._supportedShell = ['bash', 'zsh', 'fish'];
     this.logger(createLogger());


### PR DESCRIPTION
The process argument list could be different in some case like a packaged and un-packaged Electron app. In our case, the code threw an error because this variable did not exist.