### PR TITLE
fix(logger): Fix logger (new line missing)

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,8 +13,9 @@ util.inherits(CaporalTransport, winston.Transport);
 
 CaporalTransport.prototype.log = function (level, msg, meta, callback) {
   if (meta !== null && typeof meta !== 'undefined') {
-    msg += "\n" + prettyjson.render(meta) + "\n";
+    msg += "\n" + prettyjson.render(meta);
   }
+  msg += "\n";
   const levelInt = winston.levels[level];
   const stdio = levelInt <= 1 ? 'stderr' : 'stdout';
   process[stdio].write(msg);

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -65,7 +65,7 @@ describe('logger', () => {
     const oldWrite = process.stdout.write;
     process.stdout.write = write;
 
-    should(stripColor(logStr)).be.eql("foo");
+    should(stripColor(logStr)).be.eql("foo\n");
     should(callback.called).be.ok();
     should(oldWrite.called).be.ok();
 


### PR DESCRIPTION
Fix logged string which was missing new line char when no metadata were provided