### PR TITLE
fix(logger): fix logger metadata handling

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -12,7 +12,7 @@ const CaporalTransport = function (options) {
 util.inherits(CaporalTransport, winston.Transport);
 
 CaporalTransport.prototype.log = function (level, msg, meta, callback) {
-  if (meta !== null && typeof meta !== 'undefined') {
+  if (meta !== null && typeof meta === 'object' && Object.keys(meta).length) {
     msg += "\n" + prettyjson.render(meta);
   }
   msg += "\n";


### PR DESCRIPTION
fix the way we handle metadata check in logger to prevent double LF