### PR TITLE
Clarified logger examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ prog
   .command('deploy', 'The deploy command')
   .action((args, options, logger) => {
     // Available methods: 
-    // - logger.debug()
-    // - logger.info() or logger.log()
-    // - logger.warn()
-    // - logger.error()
+    // - logger.debug('message')
+    // - logger.info('message') or logger.log('level', 'message')
+    // - logger.warn('message')
+    // - logger.error('message')
     logger.info("Application deployed !");
   });
 


### PR DESCRIPTION
Added more detail and hence, hopefully clarity, to the logger examples. This should help people like myself who have never used winston, and had assumed from the way the docs were that logger.log and logger.info were the same as each other, which they're not.