### PR TITLE
Fix validator JSDoc parameter type

### DIFF
--- a/lib/argument.js
+++ b/lib/argument.js
@@ -9,7 +9,7 @@ class Argument extends GetterSetter {
    *
    * @param {String} synopsis - Option synopsis
    * @param {String} description - Option description
-   * @param {String|RegExp|Function|Number} [validator] - Option validator, used for checking or casting
+   * @param {String|RegExp|Function|Number|Array} [validator] - Option validator, used for checking or casting
    * @param {*} [defaultValue] - Default value
    * @param {Program} program - program instance
    */

--- a/lib/command.js
+++ b/lib/command.js
@@ -93,7 +93,7 @@ class Command extends GetterSetter {
    * @param {String} synopsis - Argument synopsis like `<my-argument>` or `[my-argument]`.
    * Angled brackets (e.g. `<item>`) indicate required input. Square brackets (e.g. `[env]`) indicate optional input.
    * @param {String} description - Option description
-   * @param {String|RegExp|Function|Number} [validator] - Option validator, used for checking or casting
+   * @param {String|RegExp|Function|Number|Array} [validator] - Option validator, used for checking or casting
    * @param {*} [defaultValue] - Default value
    * @public
    * @returns {Command}
@@ -364,7 +364,7 @@ class Command extends GetterSetter {
    *
    * @param {String} synopsis - Option synopsis like '-f, --force', or '-f, --file <file>', or '--with-openssl [path]'
    * @param {String} description - Option description
-   * @param {String|RegExp|Function|Number} [validator] - Option validator, used for checking or casting
+   * @param {String|RegExp|Function|Number|Array} [validator] - Option validator, used for checking or casting
    * @param {*} [defaultValue] - Default value
    * @param {Boolean} [required] - Is the option itself required
    * @public

--- a/lib/option.js
+++ b/lib/option.js
@@ -10,7 +10,7 @@ class Option extends GetterSetter {
    *
    * @param {String} synopsis - Option synopsis
    * @param {String} description - Option description
-   * @param {String|RegExp|Function|Number} [validator] - Option validator, used for checking or casting
+   * @param {String|RegExp|Function|Number|Array} [validator] - Option validator, used for checking or casting
    * @param {*} [defaultValue] - Default value
    * @param {Boolean} [required] - Is the option itself required
    * @param {Program} [program] - Program instance

--- a/lib/program.js
+++ b/lib/program.js
@@ -180,7 +180,7 @@ class Program extends GetterSetter {
    *
    * @param {String} synopsis - Option synopsis like '-f, --force', or '-f, --file <file>'
    * @param {String} description - Option description
-   * @param {String|RegExp|Function|Number} [validator] - Option validator, used for checking or casting
+   * @param {String|RegExp|Function|Number|Array} [validator] - Option validator, used for checking or casting
    * @param {*} [defaultValue] - Default value
    * @param {Boolean} [required] - Is the option itself required
    * @returns {Program}
@@ -198,7 +198,7 @@ class Program extends GetterSetter {
    * @param {String} synopsis - Argument synopsis like `<my-argument>` or `[my-argument]`.
    * Angled brackets (e.g. `<item>`) indicate required input. Square brackets (e.g. `[env]`) indicate optional input.
    * @param {String} description - Option description
-   * @param {String|RegExp|Function|Number} [validator] - Option validator, used for checking or casting
+   * @param {String|RegExp|Function|Number|Array} [validator] - Option validator, used for checking or casting
    * @param {*} [defaultValue] - Default value
    * @public
    * @returns {Command}

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -8,7 +8,7 @@ class Validator {
   /**
    *
    * @param {RegExp|Function|Number|Array} validator
-   * @param {Program} programr
+   * @param {Program} program
    */
   constructor(validator, program) {
     this._validator = validator;


### PR DESCRIPTION
I've noticed that PHPStorm ⚡️ is complaining about passing in an array as a validator for commands, arguments & options.

This pull request fixes the `validator` JSDoc type by adding `Array` to the allowed parameter types.

I've also fixed a typo in the validator class itself.

_P.S. Thanks for making such a great framework!_