### PR TITLE
Allow caporal to be used from REPL

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -21,7 +21,7 @@ class Program extends GetterSetter {
     this.description = this.makeGetterSetter('description');
     this.logger = this.makeGetterSetter('logger');
     this.bin = this.makeGetterSetter('bin');
-    this._bin = path.basename(process.argv[1]);
+    this._bin = path.basename(process.argv[1] || 'caporal');
     this._autocomplete = new Autocomplete(this);
     this._supportedShell = ['bash', 'zsh', 'fish'];
     this.logger(createLogger());


### PR DESCRIPTION
This will allow caporal to be `require`d from Node.js REPL. Useful when exploring the library's API.

Without this change, caporal would throw a `TypeError: Path must be a string. Received undefined` when requiring caporal from `node` REPL.