### PR TITLE
fix: make wording of error clearer

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -399,7 +399,7 @@ class Command extends GetterSetter {
   _run(args, options) {
     if (!this._action) {
       return this._program.fatalError(new NoActionError(
-        "Caporal Setup Error: You don't have defined an action for you program/command. Use .action()",
+        "Caporal Setup Error: You have not defined an action for you program/command. Use .action()",
         {},
         this._program
       ));


### PR DESCRIPTION
Removed clumsy wording (probably from a previous change in wording) in error displayed when
.action() is missing.