### PR TITLE
Fix typings for Typescript 2.6

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,5 +70,7 @@ declare interface Command {
 }
 
 type AutocompleteCallback = () => string[] | Promise<string[]>;
-
-export = new Caporal();
+declare module 'caporal' {
+    const _default: Caporal;
+    export default _default;
+}


### PR DESCRIPTION
It seems you cant export expressions any more in exports in typescript 2.6.

I tested the prososed change successfully with these typescript versions:

* 2.6.1
* 2.4.2