### PR TITLE
Feat add execute method for programmatic usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,35 @@ prog
 prog.parse(process.argv);
 ```
 
+### Programmatic Caporal usage
+
+You can pass arguments and options directly to Caporal API.
+
+```javascript
+#!/usr/bin/env node
+const prog = require('caporal');
+prog
+  .version('1.0.0')
+  .command('deploy', 'Our deploy command')
+  .argument('<app>', 'App to deploy')
+  .argument('<env>', 'Environment')
+  .option('--how-much', 'How much app to deploy', prog.INT, 1)
+  .action(function(args, options, logger) {
+    logger.info(args);
+    logger.info(options);
+    // {
+    //   "app": "myapp",
+    //   "env": "production"
+    // }
+    // {
+    //   "howMuch": 2
+    // }
+  });
+prog.exec(['deploy', 'myapp', 'env'], {
+  howMuch: 2
+});
+```
+
 ## Logging
 
 Inside your action(), use the logger argument (third one) to log informations.

--- a/lib/program.js
+++ b/lib/program.js
@@ -9,6 +9,7 @@ const Autocomplete = require('./autocomplete');
 const createLogger = require('./logger').createLogger;
 const tabtabComplete  = require('tabtab/src/complete');
 const WrongNumberOfArgumentError = require('./error/wrong-num-of-arg');
+const kebabCase = require('lodash.kebabcase');
 
 class Program extends GetterSetter {
 
@@ -267,6 +268,19 @@ class Program extends GetterSetter {
     return this._run(args._, options);
   }
 
+  /**
+   * Execute input command with given arguments & options
+   * @param args
+   * @param options
+   * @public
+   */
+  exec(args, options) {
+    const kebabOptions = Object.keys(options).reduce(function(result, key) {
+      result[kebabCase(key)] = options[key];
+      return result;
+    }, {});
+    return this._run(args, kebabOptions);
+  }
 }
 
 const constants = require('./constants');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2599,6 +2599,11 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "cli-table2": "^0.2.0",
     "fast-levenshtein": "^2.0.6",
     "lodash.camelcase": "^4.3.0",
+    "lodash.kebabcase": "^4.1.1",
     "micromist": "^1.0.1",
     "prettyjson": "^1.2.1",
     "tabtab": "^2.2.2",

--- a/tests/exec.js
+++ b/tests/exec.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/* global Program, logger, should, sinon */
+
+describe('Execute command', () => {
+
+  const program = new Program();
+  const actionFoo = sinon.stub();
+  const actionBar = sinon.stub();
+
+  program
+    .logger(logger)
+    .version('1.0.0')
+    .command('foo')
+    .option('--foo-option', 'foo option', program.INT, 1)
+    .action(actionFoo)
+    .command('bar')
+    .option('--bar-option', 'bar option', program.INT, 2)
+    .action(actionBar)
+
+  it('should execute 1 command', () => {
+    program.exec(['foo'], {
+      'fooOption': 11,
+    });
+
+    should(actionFoo.callCount).be.eql(1);
+    should(actionBar.callCount).be.eql(0);
+  });
+
+});


### PR DESCRIPTION
Hey @mattallty,

My company need this feature as we are mainly using Caporal for our long running process (aka workers).
While developing, we could use it programmatically against a some process manage (ie [pm2](https://github.com/Unitech/pm2)) that watch source files and reload on whatever changes.
This will save us some times and will allow us not to `^c` a running command and re-execute it manually. Especially if like us, you use Caporal in a docker container (yet we have to restart our docker-compose stack when we update our commands source).

Thanks,
Kinok