### PR TITLE
Fix #91 typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,6 +71,6 @@ declare interface Command {
 
 type AutocompleteCallback = () => string[] | Promise<string[]>;
 declare module 'caporal' {
-    const _default: Caporal;
-    export default _default;
+    const caporal: Caporal;
+    export = caporal;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,6 +36,7 @@ declare class Caporal {
     argument(synopsis: string, description: string, validator?: ValidatorArg, defaultValue?: any): Command;
 
     parse(argv: string[]): any;
+    fatalError(error: Error): void;
 }
 
 type ActionCallback = (args: { [k: string]: any },


### PR DESCRIPTION
The types were assuming that Caporal could be imported as
`import program from 'caporal'` but it can't, it has to be
imported as `import * as program from 'caporal'`