### PR TITLE
Strict mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,8 @@ declare class Caporal {
 
     parse(argv: string[]): any;
     fatalError(error: Error): void;
+
+    strict(value: boolean): Caporal;
 }
 
 type ActionCallback = (args: { [k: string]: any },

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,8 +37,6 @@ declare class Caporal {
 
     parse(argv: string[]): any;
     fatalError(error: Error): void;
-
-    strict(value: boolean): Caporal;
 }
 
 type ActionCallback = (args: { [k: string]: any },
@@ -70,6 +68,8 @@ declare interface Command {
     alias(alias: string): Command;
 
     complete(cb: AutocompleteCallback): Command;
+
+    strict(value: boolean): Command;
 }
 
 type AutocompleteCallback = () => string[] | Promise<string[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,6 +71,6 @@ declare interface Command {
 
 type AutocompleteCallback = () => string[] | Promise<string[]>;
 declare module 'caporal' {
-    const _default: Caporal;
-    export default _default;
+    const caporal: Caporal;
+    export = caporal;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,6 +36,7 @@ declare class Caporal {
     argument(synopsis: string, description: string, validator?: ValidatorArg, defaultValue?: any): Command;
 
     parse(argv: string[]): any;
+    fatalError(error: Error): void;
 }
 
 type ActionCallback = (args: { [k: string]: any },

--- a/lib/command.js
+++ b/lib/command.js
@@ -285,7 +285,11 @@ class Command extends GetterSetter {
       const value = acc[key];
       const opt = this._findOption(key);
       if (!opt) {
-        throw new UnknownOptionError(key, this, this._program);
+        if (options.strict)
+        {
+          throw new UnknownOptionError(key, this, this._program);
+        }
+        return acc;
       }
       try {
         acc[key] = opt._validate(value);

--- a/lib/command.js
+++ b/lib/command.js
@@ -35,8 +35,21 @@ class Command extends GetterSetter {
     this._default = false;
     this._lastAddedArgOrOpt = null;
     this._setupLoggerMethods();
+    this._strict = true;
   }
 
+  /**
+   * Strict mode.
+   *
+   * If set to false, then argument and option validation is reduced / turned off.
+   * This allows arguments & options to easily be passed through to other
+   * commands / scripts.
+   *
+   * @param {boolean} value
+   */
+  strict(value) {
+    this._strict = value;
+  }
 
   /**
    * Add help for the current command
@@ -285,7 +298,7 @@ class Command extends GetterSetter {
       const value = acc[key];
       const opt = this._findOption(key);
       if (!opt) {
-        if (options.strict)
+        if (this._strict)
         {
           throw new UnknownOptionError(key, this, this._program);
         }
@@ -345,7 +358,7 @@ class Command extends GetterSetter {
    */
   _validateCall(args, options) {
     // check min & max arguments accepted
-    this._checkArgsRange(args);
+    if (this._strict) this._checkArgsRange(args);
     // split args
     args = this._splitArgs(args);
     // transfrom args array to object, and set defaults for arguments not passed

--- a/lib/program.js
+++ b/lib/program.js
@@ -30,18 +30,6 @@ class Program extends GetterSetter {
   }
 
   /**
-   * Strict mode.
-   *
-   * If set to false, then "Unknown" options do not trigger an "UnknownOptionError"
-   * This allows options to easily be passed through to other commands / scripts.
-   *
-   * @param {boolean} value
-   */
-  strict(value) {
-    this._strict = value;
-  }
-
-  /**
    * @private
    */
   _help(cmdStr) {
@@ -165,9 +153,6 @@ class Program extends GetterSetter {
     } else if (options.v || options.verbose) {
       this._changeLogLevel('debug');
     }
-
-    // Default strict mode to true
-    options.strict = typeof this._strict === 'undefined' ? true : this._strict;
 
     let validated;
 

--- a/lib/program.js
+++ b/lib/program.js
@@ -30,6 +30,18 @@ class Program extends GetterSetter {
   }
 
   /**
+   * Strict mode.
+   *
+   * If set to false, then "Unknown" options do not trigger an "UnknownOptionError"
+   * This allows options to easily be passed through to other commands / scripts.
+   *
+   * @param {boolean} value
+   */
+  strict(value) {
+    this._strict = value;
+  }
+
+  /**
    * @private
    */
   _help(cmdStr) {
@@ -153,6 +165,9 @@ class Program extends GetterSetter {
     } else if (options.v || options.verbose) {
       this._changeLogLevel('debug');
     }
+
+    // Default strict mode to true
+    options.strict = typeof this._strict === 'undefined' ? true : this._strict;
 
     let validated;
 


### PR DESCRIPTION
I required the ability to disable some of the command argument and options validation so that I could pass arguments and options through to the script that is being executed by my "tsos run" command.
https://github.com/brad-jones/tsos/blob/master/packages/tsos-cli/src/app/Commands/Run.ts

FYI: This PR is branched off the work from cazgp, as I needed the fixed typescript typings too.