### PR TITLE
Make USAGE display name if available

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -34,7 +34,7 @@ class Help {
     const description = this._program.description() ? '- ' + this._program.description() : '';
     let help = `
    ${chalk.cyan(this._program.name() || this._program.bin())} ${chalk.dim(this._program.version())} ${description}
-     
+
    ${this._getUsage(command)}`;
 
     if (!command || command.name() === '' && this._program._commands.length > 1) {
@@ -105,7 +105,7 @@ class Help {
   }
 
   _getUsage(cmd) {
-    let help = `${chalk.bold('USAGE')}\n\n     ${chalk.italic(this._program.bin())} `;
+    let help = `${chalk.bold('USAGE')}\n\n     ${chalk.italic(this._program.name() || this._program.bin())} `;
     if (cmd) {
       help += colorize(this._getCommandHelp(cmd));
     } else {


### PR DESCRIPTION
Hi @mattallty 

I **really** love Caporal. It does pretty much everything, that I could have hoped for, except the one little thing mentioned in #85 

It does not really make any sense to display `this._program.bin()` if `this._program.name()` is available. I've made it so the presence of a `name` takes priority over `bin`

Applying this change, and running the `examples/pizza.js` changes it from

```
pizza.js 1.0.0

 USAGE
     pizza.js <command> [options]
```

to

```
pizzaparty 1.0.0

USAGE
     pizzaparty <command> [options]
```

when modifying it to

```
prog
  .name('pizzaparty')
  .parse(process.argv);
```

@mattallty Any chance this could get merged asap and have version `0.10.0` (or `0.9.1` depending on your versioning strategy) released? We really need this to be available for the application we are building, where it is a problem to have the `.js` leak through into the `USAGE` section because we are writing a CLI took that is installed globally

Thanks for your fantastic library!