### PR TITLE
fix: Display thrown error message when validation fails

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -246,7 +246,7 @@ class Command extends GetterSetter {
       try {
         acc[key] = arg._validate(value);
       } catch(e) {
-        throw new InvalidArgumentValueError(key, value, this, this._program);
+        throw new InvalidArgumentValueError(key, value, this, e, this._program);
       }
       return acc;
     }, {});

--- a/lib/error/invalid-argument-value.js
+++ b/lib/error/invalid-argument-value.js
@@ -5,8 +5,8 @@ const chalk = require('chalk');
 
 class InvalidArgumentValueError extends BaseError {
 
-  constructor(arg, value, command, program) {
-    let msg = `Invalid value '${value}' for argument ${chalk.italic(arg)}.`;
+  constructor(arg, value, command, originalError, program) {
+    let msg = `Invalid value '${value}' for argument ${chalk.italic(arg)}.\n   ${originalError.meta.originalError}`;
     super(msg, {arg, command, value}, program);
   }
 }

--- a/lib/error/invalid-option-value.js
+++ b/lib/error/invalid-option-value.js
@@ -6,7 +6,8 @@ const getDashedOption = require('../utils').getDashedOption;
 
 class InvalidOptionValueError extends BaseError {
   constructor(option, value, command, originalError, program) {
-    let msg = `Invalid value '${value}' for option ${chalk.italic(getDashedOption(option))}.`;
+    let msg = `Invalid value '${value}' for option ${chalk.italic(getDashedOption(option))}.\n   ${originalError.meta.originalError}`;
+
     super(msg, {option, command, originalError}, program);
   }
 }


### PR DESCRIPTION
Hi @mattallty 

I also ran into the issue described in #94 so I decided to poke around and see what I could do. He suggested an alternative solution than the one I took. Mine
is based on a couple of assumptions

1. If we get to the point where [a fn validator for an argument](https://github.com/mattallty/Caporal.js/blob/master/lib/command.js#L249) fails, or to the point where [a fn validator for an option](https://github.com/mattallty/Caporal.js/blob/master/lib/command.js#L293) then it is safe to assume that there will be an inner exception on `e` (i.e `e.meta.originalError` will have been set)
2. You were already passing along the caught exception, for the validation of options, so we should be fine doing the same for argument validation, hence I added that to the constructor arguments of `InvalidArgumentValueError`

## Examples

Argument
```
.argument('<kind>', 'Kind of pizza', (value) => { throw new Error('Pizza can only be margherita or hawaiian ')})

Error: Invalid value 'fdsf' for argument kind.
Error: Pizza can only be margherita or hawaiian
```

Option
```
.option('-n, --number <num>', 'Number of pizza', value => {throw new Error('You cannot order more than 5 pizzas.')} , 1)

Error: Invalid value '10' for option -n.
Error: You cannot order more than 5 pizzas.
```

To be honest I do not know enough about the architecture of the code base to make the call if this is a proper solution or not 😄 However I agree with the author of #94 and #51 that the thrown error should be displayed to the end user so that we can provide feedback to the user that is relevant to the context.

@mattallty would love to hear your feedback on this