### PR TITLE
style($display): Print cli version using console.log instead of logge…

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -119,7 +119,7 @@ class Program extends GetterSetter {
     }
 
     if (options.V || options.version) {
-      this.logger().info(this.version());
+      console.log(this.version());
       return process.exit(0);
     }
 


### PR DESCRIPTION
…r.info

Cli version should be displayed in plain text like display 'help' info. But using logger.info, which
maybe using format-display feature, maybe add unnecessary format style into the version info display