### PR TITLE
fix($compile): Extended ts type for logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,32 @@ prog.parse(process.argv);
 // ./myprog deploy myapp production --tail 100
 ```
 
+Or else if you prefer `typescript`
+```javascript
+#!/usr/bin/env node
+import * as prog from 'caporal';
+prog
+  .version('1.0.0')
+  // you specify arguments using .argument()
+  // 'app' is required, 'env' is optional
+  .command('deploy', 'Deploy an application')
+  .argument('<app>', 'App to deploy', /^myapp|their-app$/)
+  .argument('[env]', 'Environment to deploy on', /^dev|staging|production$/, 'local')
+  // you specify options using .option()
+  // if --tail is passed, its value is required
+  .option('--tail <lines>', 'Tail <lines> lines of logs after deploy', prog.INT)
+  .action(function(args, options, logger) {
+    // args and options are objects
+    // args = {"app": "myapp", "env": "production"}
+    // options = {"tail" : 100}
+  });
+
+prog.parse(process.argv);
+
+// ./myprog deploy myapp production --tail 100
+```
+
+
 ### Variadic arguments
 
 You can use `...` to indicate variadic arguments. In that case, the resulted value will be an array.

--- a/examples/pizza/package.json
+++ b/examples/pizza/package.json
@@ -6,10 +6,14 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies" : {
-    "caporal": "file:../../"
+  "dependencies": {
+    "@types/node": "^11.9.4",
+    "caporal": "file:../../",
+    "tsc": "^1.20150623.0"
   },
-  "bin" : { "fly" : "./pizza.js" },
+  "bin": {
+    "fly": "./pizza.js"
+  },
   "author": "",
   "license": "ISC"
 }

--- a/examples/pizza/typescript.ts
+++ b/examples/pizza/typescript.ts
@@ -1,0 +1,17 @@
+import * as prog from 'caporal';
+
+prog
+    .version('1.0.0')
+    // you specify arguments using .argument()
+    // 'app' is required, 'env' is optional
+    .command('ts', 'Basic typescript example')
+    .argument('[arg]', 'argument desc', /^.*$/, 'default arg')
+    .option('--option <option>', 'option desc', prog.STRING, 'default option')
+    .action((args, options, logger) => {
+        logger.info('Hello');
+        logger.info(options);
+        logger.info("%j", args);
+    });
+
+
+prog.parse(process.argv);

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,11 +52,16 @@ type ValidatorArg = string[]|string|RegExp|ValidatorFn|Number;
 type ValidatorFn = (str: string) => any;
 
 declare interface Logger {
-    debug(str: string): void;
-    info(str: string): void;
-    log(str: string): void;
-    warn(str: string): void;
-    error(str: string): void;
+    debug(str: string|object): void;
+    debug(format: string, ...mixed: any[]): void;
+    info(str: string|object): void;
+    info(format: string, ...mixed: any[]): void;
+    log(str: string|object): void;
+    log(format: string, ...mixed: any[]): void;
+    warn(str: string|object): void;
+    warn(format: string, ...mixed: any[]): void;
+    error(str: string|object): void;
+    error(format: string, ...mixed: any[]): void;
 }
 
 declare interface Command {


### PR DESCRIPTION
Logger interface handle many input types that were not supported as per `printf` style & `object`.
Also added a basic ts example.