### PR TITLE
ci: add docs folders to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,8 @@
 npm-debug.log
 node_modules
 coverage
+docs
+docs-src
 .idea
 tests
 assets


### PR DESCRIPTION
Fixes https://github.com/mattallty/Caporal.js/issues/113
As looks that is not really solved.

It also solves this retireJS errors:
https://github.com/twbs/bootstrap/issues/28236
https://github.com/twbs/bootstrap/issues/20184
https://github.com/jquery/jquery/issues/2432
