### PR TITLE
chore: Updated lodash version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -691,6 +691,12 @@
             "path-is-absolute": "^1.0.0"
           }
         },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -3139,9 +3145,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "cli-table3": "^0.5.0",
     "colorette": "1.0.1",
     "fast-levenshtein": "^2.0.6",
-    "lodash": "4.17.11",
+    "lodash": "4.17.14",
     "micromist": "1.1.0",
     "prettyjson": "^1.2.1",
     "tabtab": "^2.2.2",


### PR DESCRIPTION
Updated lodash version to address security vulnerabilities.

Addresses #153 (unless you'd rather switch to using a caret)