### PR TITLE
Change options sort #191

### DIFF
--- a/src/help/__tests__/help.spec.ts
+++ b/src/help/__tests__/help.spec.ts
@@ -48,6 +48,16 @@ describe("help", () => {
       return expect(strip(await getHelp(prog))).toMatchSnapshot()
     })
 
+    it("should display help for a program with options in order given", async () => {
+      prog
+        .argument("<foo>", "Mandarory foo arg")
+        .argument("[other]", "Other args")
+        .option("-f, --file <file>", " Output file")
+        .option("-e, --ext <extension>", " extension file")
+      return expect(strip(await getHelp(prog))).toMatchSnapshot()
+    })
+
+
     it("should display help for a program having at least one command (with args & options)", async () => {
       prog
         .command("test-command", "Test command")

--- a/src/help/templates/command.ts
+++ b/src/help/templates/command.ts
@@ -10,7 +10,7 @@ import sortBy from "lodash/sortBy"
 export const command: Template = async (ctx: TemplateContext) => {
   const { cmd, globalOptions: globalFlags, eol, eol3, colorize, tpl } = ctx
 
-  const options = sortBy(cmd!.options, "name"),
+  const options = sortBy(cmd!.options, "required"),
     globalOptions = Array.from(globalFlags.keys())
 
   const help =


### PR DESCRIPTION
disable sort by name for `options` ,remain  in the given order 