### PR TITLE
Fix auto-completion

### DIFF
--- a/src/autocomplete/__tests__/autocomplete.spec.ts
+++ b/src/autocomplete/__tests__/autocomplete.spec.ts
@@ -31,7 +31,7 @@ function makeFakeEnv(
 describe("autocomplete", () => {
   describe("complete()", () => {
     it("should auto-complete command list", async () => {
-      const argv = ""
+      const argv = " |"
       await expect(complete(program, makeFakeEnv(argv))).resolves.toEqual([
         {
           name: "help",

--- a/src/autocomplete/__tests__/autocomplete.spec.ts
+++ b/src/autocomplete/__tests__/autocomplete.spec.ts
@@ -34,6 +34,10 @@ describe("autocomplete", () => {
       const argv = ""
       await expect(complete(program, makeFakeEnv(argv))).resolves.toEqual([
         {
+          name: "help",
+          description: expect.any(String),
+        },
+        {
           name: "order",
           description: expect.any(String),
         },

--- a/src/autocomplete/__tests__/autocomplete.spec.ts
+++ b/src/autocomplete/__tests__/autocomplete.spec.ts
@@ -30,6 +30,20 @@ function makeFakeEnv(
 
 describe("autocomplete", () => {
   describe("complete()", () => {
+    it("should auto-complete command list", async () => {
+      const argv = ""
+      await expect(complete(program, makeFakeEnv(argv))).resolves.toEqual([
+        {
+          name: "order",
+          description: expect.any(String),
+        },
+        {
+          name: "cancel",
+          description: expect.any(String),
+        },
+      ])
+    })
+
     it("should auto-complete command name if possible", async () => {
       const argv = "ord|"
       await expect(complete(program, makeFakeEnv(argv))).resolves.toEqual([

--- a/src/program/__tests__/program.spec.ts
+++ b/src/program/__tests__/program.spec.ts
@@ -311,6 +311,6 @@ describe("Program", () => {
   test("program should not fail when trying to run completion command", async () => {
     const action = jest.fn().mockReturnValue("ok")
     prog.command("test", "test command").action(action)
-    await expect(prog.run(["completion", "--", ""])).resolves.toBeDefined()
+    await expect(prog.run(["completion", "--", ""])).resolves.not.toThrowError()
   })
 })

--- a/src/program/__tests__/program.spec.ts
+++ b/src/program/__tests__/program.spec.ts
@@ -307,4 +307,10 @@ describe("Program", () => {
     await expect(prog.run(["test", "my-arg"])).resolves.toBe(true)
     expect(logger.log).toHaveBeenCalledWith("foo")
   })
+
+  test("program should not fail when trying to run completion command", async () => {
+    const action = jest.fn().mockReturnValue("ok")
+    prog.command("test", "test command").action(action)
+    await expect(prog.run(["completion", "--", ""])).resolves.toBeDefined()
+  })
 })


### PR DESCRIPTION
#200 

Auto completion appears to have been broken since v2.x was released since `Program` doesn't have any special handling for the `completion` command that the shell scripts invoke. Additionally, the `complete` function doesn't handle the case of auto completing top level commands when no partial command has been entered.

This PR will correct these issues, starting with tests that demonstrate the problems.