### PR TITLE
fix bug with parsing equals character (=) in the option value

### DIFF
--- a/src/parser/__tests__/parser.spec.ts
+++ b/src/parser/__tests__/parser.spec.ts
@@ -156,6 +156,22 @@ describe("Parser", () => {
       })
     })
 
+    it("should parse option with value having \"=\" (equals) character, using equals notation", () => {
+      const line = "--opt=field=val"
+      const result = parseLine(line)
+      expect(result.options).toEqual({
+        opt: 'field=val'
+      })
+    })
+
+    it("should parse option with value having \"=\" (equals) character, using space notation", () => {
+      const line = "--opt field=val"
+      const result = parseLine(line)
+      expect(result.options).toEqual({
+        opt: 'field=val'
+      })
+    })
+
     describe("should handle aliases", () => {
       test("with simple options", () => {
         const line = "--my-opt true --int 23456 --float=3.14159265 --on=on -t=my-type"

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -287,7 +287,9 @@ class OptionParser {
       return false
     }
 
-    const [name, rawval] = tree.current.split("=", 2)
+    const parts = tree.current.split("=")
+    const name = parts.shift() || ""
+    const rawval = parts.length ? parts.join("=") : undefined
     const concatOpts = isConcatenatedOpt(name)
 
     if (concatOpts) {


### PR DESCRIPTION
Parser changed not to discard the part of the option value that comes after the equals character in the string.

Issue: https://github.com/mattallty/Caporal.js/issues/81