### PR TITLE
fix: link to help guide

### DIFF
--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -132,7 +132,7 @@ placeholder. let's take some examples:
 #### `.help(contents: string, opts)`
 
 `.help()` lets you customize the command help.
-Learn more in the [help section](/guide/help) of this guide.
+Learn more in the [help section](/guide/help.html) of this guide.
 
 ### Hiding from help
 


### PR DESCRIPTION
The current link is a 404 and it seems like it should be linking to https://caporal.io/guide/help.html