### PR TITLE
fix: unpin dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,17 +116,17 @@
   },
   "dependencies": {
     "@types/glob": "^7.1.1",
-    "@types/lodash": "4.14.149",
+    "@types/lodash": "^4.14.149",
     "@types/node": "13.9.3",
-    "@types/table": "5.0.0",
+    "@types/table": "^5.0.0",
     "@types/tabtab": "^3.0.1",
     "@types/wrap-ansi": "^3.0.0",
-    "chalk": "3.0.0",
+    "chalk": "^3.0.0",
     "glob": "^7.1.6",
-    "lodash": "4.17.21",
-    "table": "5.4.6",
+    "lodash": "^4.17.21",
+    "table": "^5.4.6",
     "tabtab": "^3.0.2",
-    "winston": "3.2.1",
+    "winston": "^3.2.1",
     "wrap-ansi": "^6.2.0"
   },
   "config": {


### PR DESCRIPTION
Currently direct dependencies are pinned to specific patch versions,
as a result, projects that use this repository cannot respond to
transitive dependency updates, for example #210 updates lodash to
address CVE‑2020-8203, however other projects need to wait for Caporal
to do this and update after a new version has been published, and cannot be more proactive to address vulnerabilities in transitive dependencies.

Other projects have been working around this by adding overrides to their package files, e.g: https://github.com/Scrivito/scrivito_example_app_js/commit/9bd42031c54a7693fdd328dc42fa979a48f3c19d

Beyond this, it looks like releases have not been pushed out recently, I'm guessing this is due to incorrectly formatted commit messages? So people who use this library are still currently stuck with CVE‑2020-8203. This change should prevent this happening going forward.